### PR TITLE
fix: update brace-expansion security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,8 +1862,8 @@
       "optional": true
     },
     "node_modules/@angular/compiler-cli/node_modules/fsevents/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "inBundle": true,
       "optional": true,
@@ -1871,7 +1871,7 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       },
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz"
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz"
     },
     "node_modules/@angular/compiler-cli/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",


### PR DESCRIPTION
Updates brace-expansion instances to patched maintenance-line releases, including the follow-up DoS fix.