### PR TITLE
fix: upgrade Angular compiler security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "8.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.14.tgz",
-      "integrity": "sha512-ABZO4E7eeFA1QyJ2trDezxeQM5ZFa1dXw1Mpl/+1vuXDKNjJgNyWYwKp/NwRkLmrsuV0yv4UDCDe4kJOGbPKnw==",
+      "version": "20.3.27",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.27.tgz",
+      "integrity": "sha512-in3THZ678GAYuOR9RZV18+zZz0KGhlGikyUEfLeALLjGf9ZaR3n+t19BmYx6G2VkF/Xqadne1omQ2vbl6PRASA==",
       "dependencies": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@angular-redux/store": "^10.0.0",
     "@angular/animations": "~8.2.14",
     "@angular/common": "~8.2.14",
-    "@angular/compiler": "~8.2.14",
+    "@angular/compiler": "~20.3.27",
     "@angular/core": "~20.3.27",
     "@angular/forms": "~8.2.14",
     "@angular/platform-browser": "~8.2.14",


### PR DESCRIPTION
Aligns the direct @angular/compiler dependency and root lockfile instance with patched Angular 20.3.27. Full CI/build compatibility must pass before further migration work.